### PR TITLE
4桁の乱数が名前のルームを作成する機能を追加

### DIFF
--- a/Assets/Scenes/CreateRoom.cs
+++ b/Assets/Scenes/CreateRoom.cs
@@ -1,0 +1,23 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Fusion;
+
+public class CreateRoom : MonoBehaviour
+{
+    public NetworkRunner networkRunnerPrefab;
+    private async void Start()
+    {
+        //prefab(ゲームオブジェクトの設計書)を使ってゲームオブジェクトをコピーする
+        var networkRunner = Instantiate(networkRunnerPrefab);
+        //部屋を作る
+        var result = await networkRunner.StartGame(new StartGameArgs
+        {
+            SessionName = RoomNumberText.roomNumStr,
+            GameMode = GameMode.Shared
+        });
+        Debug.Log(result);
+        Debug.Log($"SessionName:{networkRunner.SessionInfo.Name}");
+    }
+
+}

--- a/Assets/Scenes/CreateRoom.cs.meta
+++ b/Assets/Scenes/CreateRoom.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f705edd4beda9d34d8e63a5c5e441167
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Lobby.unity
+++ b/Assets/Scenes/Lobby.unity
@@ -172,7 +172,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 70acb71420fe7ec4691ac2d831511d54, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  roomNumStr: 
 --- !u!114 &51617810
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -521,6 +520,74 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 373044829}
   m_CullTransparentMesh: 1
+--- !u!1001 &887213625
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5532301645301842034, guid: 4592f7252ba140a4ab4dc7cb588be612, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 265
+      objectReference: {fileID: 0}
+    - target: {fileID: 5532301645301842034, guid: 4592f7252ba140a4ab4dc7cb588be612, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 149
+      objectReference: {fileID: 0}
+    - target: {fileID: 5532301645301842034, guid: 4592f7252ba140a4ab4dc7cb588be612, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5532301645301842034, guid: 4592f7252ba140a4ab4dc7cb588be612, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5532301645301842034, guid: 4592f7252ba140a4ab4dc7cb588be612, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5532301645301842034, guid: 4592f7252ba140a4ab4dc7cb588be612, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5532301645301842034, guid: 4592f7252ba140a4ab4dc7cb588be612, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5532301645301842034, guid: 4592f7252ba140a4ab4dc7cb588be612, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5532301645301842034, guid: 4592f7252ba140a4ab4dc7cb588be612, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5532301645301842034, guid: 4592f7252ba140a4ab4dc7cb588be612, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6051598608835835358, guid: 4592f7252ba140a4ab4dc7cb588be612, type: 3}
+      propertyPath: m_Name
+      value: NetworkRunner
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4592f7252ba140a4ab4dc7cb588be612, type: 3}
+--- !u!114 &887213626 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8769848905875267440, guid: 4592f7252ba140a4ab4dc7cb588be612, type: 3}
+  m_PrefabInstance: {fileID: 887213625}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1199893898, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &936600815
 GameObject:
   m_ObjectHideFlags: 0
@@ -830,6 +897,51 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1661993741
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1661993743}
+  - component: {fileID: 1661993742}
+  m_Layer: 0
+  m_Name: CreateRoom
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1661993742
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1661993741}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f705edd4beda9d34d8e63a5c5e441167, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  networkRunnerPrefab: {fileID: 887213626}
+--- !u!4 &1661993743
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1661993741}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 265, y: 149, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1911158847
 GameObject:
   m_ObjectHideFlags: 0
@@ -1132,3 +1244,5 @@ SceneRoots:
   - {fileID: 936600819}
   - {fileID: 970431452}
   - {fileID: 1388548253}
+  - {fileID: 1661993743}
+  - {fileID: 887213625}

--- a/Assets/Scenes/NetworkRunner.prefab
+++ b/Assets/Scenes/NetworkRunner.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6051598608835835358
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5532301645301842034}
+  - component: {fileID: 8769848905875267440}
+  m_Layer: 0
+  m_Name: NetworkRunner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5532301645301842034
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6051598608835835358}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 265, y: 149, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8769848905875267440
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6051598608835835358}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1199893898, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scenes/NetworkRunner.prefab.meta
+++ b/Assets/Scenes/NetworkRunner.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4592f7252ba140a4ab4dc7cb588be612
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/RoomNumber.cs
+++ b/Assets/Scenes/RoomNumber.cs
@@ -6,9 +6,9 @@ using UnityEngine.UI;
 public class RoomNumberText : MonoBehaviour
 {
     public static int roomNum;
-    public string roomNumStr;
+    public static string roomNumStr;
     private Text roomNumText;
-    void Start()
+    void Awake()
     {
         CreateRoomNum();
         roomNumStr = roomNum.ToString();


### PR DESCRIPTION
## やったこと
<!--
「このPRで何を実現したか」を一言で簡潔に列挙してください。
チームでの認識合わせのため、最初に目を通す人の「PRを読むモチベーション」になります。
- ~~~画面を追加しました
- ~~~API連携の処理をした。
-->
- 生成した4桁の乱数が名前となるルームを作るスクリプトを追加しました。
- NetworkRunnerのプレハブをScenesフォルダに追加しました。
- RoomNumber生成のイベント関数をStart()からAwake()に変更しました。

## 懸念点 / レビューしてほしいポイント
<!--
レビューの観点を明確にしておくと、レビュワーも的確なフィードバックができます。
「この書き方でよかったか不安」「stateの持ち方に自信がない」など、些細なことでもOKです。
-->
- NetworkRunner : 
　マッチメイキングやネットワークの接続等を行うコンポーネント（1つのルームにつき1つのNetworkRunner）
　
- 生成される乱数とルームの名前が一致していることを確認していただきたいです。
- 動くんですけどwarningが出ています。Networkconfigのティックレートがあってないかもです。（よくわからなかったのでいったんなにも触りませんでした、、すみません）
- NetworkRunnerのプレハブをScenesフォルダにそのまま入れてしまっているので違う場所に保存したほうがいいとかあったら教えてほしいです！

## ひとこと
<!--
シンプルな感想を書きましょう！
-->このPRが通ったら次はロビーにユーザー名を表示する機能を作ります！